### PR TITLE
feat: support Lima VMs iptables rules

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.17 as build
 
 WORKDIR /build
 
-COPY go.* .
+COPY go.* ./
 
 RUN go mod download
 
@@ -12,8 +12,9 @@ RUN go build -o app main.go
 
 FROM debian:11-slim
 
-RUN apt-get update && apt-get install -y \
-  iptables
+RUN apt-get update && \
+    apt-get install -y iptables && \
+    update-alternatives --set iptables /usr/sbin/iptables-legacy
 
 COPY --from=build /build/app .
 

--- a/client/main.go
+++ b/client/main.go
@@ -186,4 +186,18 @@ func main() {
 		fmt.Printf("Failed to add iptables nat rule: %v\n", err)
 		os.Exit(ExitSetupFailed)
 	}
+
+	fmt.Println("Adding iptables FORWARD rule for host WireGuard IP")
+
+	// Add iptables rule to allow incoming traffic from hostPeerIp
+	// This is needed by LIMA-based Docker VM hosts
+	err = ipt.AppendUnique(
+		"filter", "FORWARD",
+		"-s", hostPeerIp,
+		"-p", "tcp", "-j", "ACCEPT",
+	)
+	if err != nil {
+		fmt.Printf("Failed to add iptables forward rule: %v\n", err)
+		os.Exit(ExitSetupFailed)
+	}
 }


### PR DESCRIPTION
New Features:
 - Adds support for Lima-based VM by added a necessary `iptables` rule

Caveats:
 - For Colima, still need to manually symlink `/var/run/docker.sock`

TODO:
 - Update documentation