### PR TITLE
fix: resolve docker context when running as root via launchd

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,8 +57,9 @@ Before releasing, verify:
 1. `make build` succeeds
 2. `sudo ./docker-mac-net-connect` starts and creates the tunnel
 3. `./scripts/e2e-test.sh` passes
-4. Stop and restart Docker Desktop - verify the server reconnects automatically
-5. For Homebrew releases: `brew upgrade chipmk/tap/docker-mac-net-connect` and `sudo brew services restart chipmk/tap/docker-mac-net-connect`
+4. Test as root (simulates launchd): `sudo -i $(pwd)/docker-mac-net-connect`
+5. Stop and restart Docker Desktop - verify the server reconnects automatically
+6. For Homebrew releases: `brew upgrade chipmk/tap/docker-mac-net-connect` and `sudo brew services restart chipmk/tap/docker-mac-net-connect`
 
 ## Releases
 

--- a/main.go
+++ b/main.go
@@ -198,8 +198,11 @@ func main() {
 				logger.Verbosef("Failed to lookup user %s: %v\n", consoleUser, err)
 			} else {
 				dockerConfig := filepath.Join(u.HomeDir, ".docker")
-				os.Setenv("DOCKER_CONFIG", dockerConfig)
-				logger.Verbosef("Set DOCKER_CONFIG to %s (console user: %s)\n", dockerConfig, consoleUser)
+				if err := os.Setenv("DOCKER_CONFIG", dockerConfig); err != nil {
+					logger.Verbosef("Failed to set DOCKER_CONFIG: %v\n", err)
+				} else {
+					logger.Verbosef("Set DOCKER_CONFIG to %s (console user: %s)\n", dockerConfig, consoleUser)
+				}
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,8 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"os/user"
+	"path/filepath"
 	"strconv"
 	"syscall"
 	"time"
@@ -183,15 +185,36 @@ func main() {
 
 	logger.Verbosef("Interface %s created\n", interfaceName)
 
-	dockerHost, err := dcontext.CurrentDockerHost()
-	if err != nil {
-		logger.Errorf("Failed to resolve Docker host from context: %v", err)
-		os.Exit(ExitSetupFailed)
+	// When running as root (e.g. via launchd), the docker config lives under
+	// the console user's home directory. Set DOCKER_CONFIG so the context
+	// resolver can find it.
+	if os.Getenv("DOCKER_CONFIG") == "" {
+		consoleUser, err := getConsoleUser()
+		if err != nil {
+			logger.Verbosef("Failed to get console user: %v\n", err)
+		} else {
+			u, err := user.Lookup(consoleUser)
+			if err != nil {
+				logger.Verbosef("Failed to lookup user %s: %v\n", consoleUser, err)
+			} else {
+				dockerConfig := filepath.Join(u.HomeDir, ".docker")
+				os.Setenv("DOCKER_CONFIG", dockerConfig)
+				logger.Verbosef("Set DOCKER_CONFIG to %s (console user: %s)\n", dockerConfig, consoleUser)
+			}
+		}
 	}
 
-	logger.Verbosef("Using Docker host: %s\n", dockerHost)
+	var hostOpt client.Opt
+	dockerHost, err := dcontext.CurrentDockerHost()
+	if err != nil {
+		logger.Verbosef("Failed to resolve Docker host from context: %v, falling back to env/default\n", err)
+		hostOpt = client.FromEnv
+	} else {
+		logger.Verbosef("Using Docker host: %s\n", dockerHost)
+		hostOpt = client.WithHost(dockerHost)
+	}
 
-	cli, err := client.NewClientWithOpts(client.WithHost(dockerHost), client.WithAPIVersionNegotiation())
+	cli, err := client.NewClientWithOpts(hostOpt, client.WithAPIVersionNegotiation())
 	if err != nil {
 		logger.Errorf("Failed to create Docker client: %v", err)
 		os.Exit(ExitSetupFailed)
@@ -360,4 +383,25 @@ func setupVm(
 	fmt.Println("Setup container complete")
 
 	return nil
+}
+
+// getConsoleUser returns the username of the currently logged-in GUI user
+// by checking the owner of /dev/console.
+func getConsoleUser() (string, error) {
+	info, err := os.Stat("/dev/console")
+	if err != nil {
+		return "", fmt.Errorf("stat /dev/console: %w", err)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "", fmt.Errorf("unexpected stat type for /dev/console")
+	}
+	u, err := user.LookupId(strconv.FormatUint(uint64(stat.Uid), 10))
+	if err != nil {
+		return "", fmt.Errorf("lookup uid %d: %w", stat.Uid, err)
+	}
+	if u.Username == "root" {
+		return "", fmt.Errorf("no console user logged in")
+	}
+	return u.Username, nil
 }


### PR DESCRIPTION
When installed via Homebrew, the binary runs as a root LaunchDaemon which has no `~/.docker/config.json`. This meant docker context resolution always failed, and there was no fallback. So even if you were using the default docker socket, it wouldn't use it.

This fixes the issue by:
1. Detecting the logged in user via who owns `/dev/console`, then points `DOCKER_CONFIG` to their docker config directory before resolving the context
2. If context resolution still fails, it falls back to `client.FromEnv` which respects `DOCKER_HOST` and then the default socket

## Test plan

- `sudo ./docker-mac-net-connect` works (normal sudo, HOME preserved)
- `sudo -i $(pwd)/docker-mac-net-connect` works (simulates launchd with root HOME)
- Falls back gracefully if no console user or no docker config exists
